### PR TITLE
Maven compile task fails on a fresh clone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>ml.dmlc</groupId>
 			<artifactId>xgboost4j</artifactId>
-			<version>0.7</version>
+			<version>0.72</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
As of 620eaad5097, `mvn compile` fails due to missing artifact `ml.dmlc:xgboost4j:jar:0.7`.

For more details, see error below:

```
[INFO] --------------------------< recsysy2018:vl6 >---------------------------
[INFO] Building vl6 0.0.1-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The POM for ml.dmlc:xgboost4j:jar:0.7 is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.637 s
[INFO] Finished at: 2018-08-13T10:52:31+03:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project vl6: Could not resolve dependencies for project recsysy2018:vl6:jar:0.0.1-SNAPSHOT: Failure to find ml.dmlc:xgboost4j:jar:0.7 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
```

A possible fix is to use xgboost4j version 0.72.

Thank you for sharing your contribution! 